### PR TITLE
Add Irish language support to dropdown and days of the week mapping.

### DIFF
--- a/ESPTimeCast_ESP32/data/index.html
+++ b/ESPTimeCast_ESP32/data/index.html
@@ -444,6 +444,7 @@ textarea::placeholder {
     <option value="et">Estonian</option>
     <option value="fi">Finnish</option>
     <option value="fr">French</option>
+    <option value="ga">Irish</option>
     <option value="de">German</option>
     <option value="hu">Hungarian</option>
     <option value="it">Italian</option>

--- a/ESPTimeCast_ESP32/days_lookup.h
+++ b/ESPTimeCast_ESP32/days_lookup.h
@@ -17,6 +17,7 @@ const DaysOfWeekMapping days_mappings[] = {
     { "et", { "p&a",   "e&s",   "t&e",   "k&o",   "n&e",   "r&e",   "l&a" } },
     { "fi", { "s&u&n", "m&a&a", "t&i&s", "k&e&s", "t&o&r", "p&e&r", "l&a&u" } },
     { "fr", { "d&i&m", "l&u&n", "m&a&r", "m&e&r", "j&e&u", "v&e&n", "s&a&m" } },
+    { "ga", { "d&o&m", "l&u&a", "m&a&i", "c&e&a", "d&e&a", "a&o&i", "s&a&t" } },
     { "hr", { "n&e&d", "p&o&n", "u&t&o", "s&r&i", "c&e&t", "p&e&t", "s&u&b" } },
     { "hu", { "v&a&s", "h&e&t", "k&e&d", "s&z&e", "c&s&u", "p&e&t", "s&z&o" } },
     { "it", { "d&o&m", "l&u&n", "m&a&r", "m&e&r", "g&i&o", "v&e&n", "s&a&b" } },

--- a/ESPTimeCast_ESP8266/data/index.html
+++ b/ESPTimeCast_ESP8266/data/index.html
@@ -444,6 +444,7 @@ textarea::placeholder {
     <option value="et">Estonian</option>
     <option value="fi">Finnish</option>
     <option value="fr">French</option>
+    <option value="ga">Irish</option>
     <option value="de">German</option>
     <option value="hu">Hungarian</option>
     <option value="it">Italian</option>

--- a/ESPTimeCast_ESP8266/days_lookup.h
+++ b/ESPTimeCast_ESP8266/days_lookup.h
@@ -17,6 +17,7 @@ const DaysOfWeekMapping days_mappings[] = {
     { "et", { "p&a",   "e&s",   "t&e",   "k&o",   "n&e",   "r&e",   "l&a" } },
     { "fi", { "s&u&n", "m&a&a", "t&i&s", "k&e&s", "t&o&r", "p&e&r", "l&a&u" } },
     { "fr", { "d&i&m", "l&u&n", "m&a&r", "m&e&r", "j&e&u", "v&e&n", "s&a&m" } },
+    { "ga", { "d&o&m", "l&u&a", "m&a&i", "c&e&a", "d&e&a", "a&o&i", "s&a&t" } },
     { "hr", { "n&e&d", "p&o&n", "u&t&o", "s&r&i", "c&e&t", "p&e&t", "s&u&b" } },
     { "hu", { "v&a&s", "h&e&t", "k&e&d", "s&z&e", "c&s&u", "p&e&t", "s&z&o" } },
     { "it", { "d&o&m", "l&u&n", "m&a&r", "m&e&r", "g&i&o", "v&e&n", "s&a&b" } },


### PR DESCRIPTION
This change adds support for the Irish language (ga) for the days of the week. This includes:
- Adding 'ga' to the `days_mappings` in `days_lookup.h`
- Adding 'Irish' to the language dropdown in `index.html`