### PR TITLE
Better German conversion

### DIFF
--- a/ESPTimeCast_ESP32/ESPTimeCast_ESP32.ino
+++ b/ESPTimeCast_ESP32/ESPTimeCast_ESP32.ino
@@ -1000,7 +1000,7 @@ String normalizeWeatherDescription(String str) {
 
   // Latin diacritics → ASCII
   str.replace("å", "a");
-  str.replace("ä", "a");
+  str.replace("ä", "ae");
   str.replace("à", "a");
   str.replace("á", "a");
   str.replace("â", "a");
@@ -1051,7 +1051,7 @@ String normalizeWeatherDescription(String str) {
   str.replace("ó", "o");
   str.replace("ò", "o");
   str.replace("ô", "o");
-  str.replace("ö", "o");
+  str.replace("ö", "oe");
   str.replace("õ", "o");
   str.replace("ø", "o");
   str.replace("ō", "o");
@@ -1074,7 +1074,7 @@ String normalizeWeatherDescription(String str) {
   str.replace("ú", "u");
   str.replace("ù", "u");
   str.replace("û", "u");
-  str.replace("ü", "u");
+  str.replace("ü", "ue");
   str.replace("ū", "u");
   str.replace("ů", "u");
   str.replace("ű", "u");

--- a/ESPTimeCast_ESP32/days_lookup.h
+++ b/ESPTimeCast_ESP32/days_lookup.h
@@ -10,7 +10,7 @@ const DaysOfWeekMapping days_mappings[] = {
     { "af", { "s&u&n", "m&a&a", "d&i&n", "w&o&e", "d&o&n", "v&r&y", "s&o&n" } },
     { "cs", { "n&e&d", "p&o&n", "u&t&e", "s&t&r", "c&t&v", "p&a&t", "s&o&b" } },
     { "da", { "s&o&n", "m&a&n", "t&i&r", "o&n&s", "t&o&r", "f&r&e", "l&o&r" } },
-    { "de", { "s&o&n", "m&o&n", "d&i&e", "m&i&t", "d&o&n", "f&r&e", "s&a&m" } },
+    { "de", { "s&o", "m&o", "d&i", "m&i", "d&o", "f&r", "s&a" } },
     { "en", { "s&u&n", "m&o&n", "t&u&e", "w&e&d", "t&h&u", "f&r&i", "s&a&t" } },
     { "eo", { "d&i&m", "l&u&n", "m&a&r", "m&e&r", "j&a&u", "v&e&n", "s&a&b" } },
     { "es", { "d&o&m", "l&u&n", "m&a&r", "m&i&e", "j&u&e", "v&i&e", "s&a&b" } },

--- a/ESPTimeCast_ESP8266/ESPTimeCast_ESP8266.ino
+++ b/ESPTimeCast_ESP8266/ESPTimeCast_ESP8266.ino
@@ -999,7 +999,7 @@ String normalizeWeatherDescription(String str) {
 
   // Latin diacritics → ASCII
   str.replace("å", "a");
-  str.replace("ä", "a");
+  str.replace("ä", "ae");
   str.replace("à", "a");
   str.replace("á", "a");
   str.replace("â", "a");
@@ -1050,7 +1050,7 @@ String normalizeWeatherDescription(String str) {
   str.replace("ó", "o");
   str.replace("ò", "o");
   str.replace("ô", "o");
-  str.replace("ö", "o");
+  str.replace("ö", "oe");
   str.replace("õ", "o");
   str.replace("ø", "o");
   str.replace("ō", "o");
@@ -1073,7 +1073,7 @@ String normalizeWeatherDescription(String str) {
   str.replace("ú", "u");
   str.replace("ù", "u");
   str.replace("û", "u");
-  str.replace("ü", "u");
+  str.replace("ü", "ue");
   str.replace("ū", "u");
   str.replace("ů", "u");
   str.replace("ű", "u");

--- a/ESPTimeCast_ESP8266/days_lookup.h
+++ b/ESPTimeCast_ESP8266/days_lookup.h
@@ -10,7 +10,7 @@ const DaysOfWeekMapping days_mappings[] = {
     { "af", { "s&u&n", "m&a&a", "d&i&n", "w&o&e", "d&o&n", "v&r&y", "s&o&n" } },
     { "cs", { "n&e&d", "p&o&n", "u&t&e", "s&t&r", "c&t&v", "p&a&t", "s&o&b" } },
     { "da", { "s&o&n", "m&a&n", "t&i&r", "o&n&s", "t&o&r", "f&r&e", "l&o&r" } },
-    { "de", { "s&o&n", "m&o&n", "d&i&e", "m&i&t", "d&o&n", "f&r&e", "s&a&m" } },
+    { "de", { "s&o", "m&o", "d&i", "m&i", "d&o", "f&r", "s&a" } },
     { "en", { "s&u&n", "m&o&n", "t&u&e", "w&e&d", "t&h&u", "f&r&i", "s&a&t" } },
     { "eo", { "d&i&m", "l&u&n", "m&a&r", "m&e&r", "j&a&u", "v&e&n", "s&a&b" } },
     { "es", { "d&o&m", "l&u&n", "m&a&r", "m&i&e", "j&u&e", "v&i&e", "s&a&b" } },


### PR DESCRIPTION
Changed Weekday abbreviations to commonly used ones for german.
Fixed umlaut conversion as well.