### PR TITLE
💡 feat: Buzzer + Button UI config

### DIFF
--- a/ESPTimeCast_ESP32/ESPTimeCast_ESP32.ino
+++ b/ESPTimeCast_ESP32/ESPTimeCast_ESP32.ino
@@ -76,6 +76,13 @@ Preferences prefs;
 int CLK_PIN;
 int CS_PIN;
 int DATA_PIN;
+int BUZZER_PIN = -1;    // -1 = not configured
+bool buzzerEnabled = false;
+int BUTTON_PIN = -1;    // -1 = not configured
+bool buttonEnabled = false;
+String buttonShortPressAction = "next_mode";
+String buttonLongPressAction  = "display_off";
+#define BUTTON_LONG_PRESS_MS 800
 MD_Parola P = MD_Parola(HARDWARE_TYPE, L_DATA, L_CLK, L_CS, MAX_DEVICES);
 AsyncWebServer server(80);
 
@@ -365,6 +372,10 @@ void loadConfig() {
     doc[F("sunsetHour")] = sunsetHour;
     doc[F("sunsetMinute")] = sunsetMinute;
     doc[F("clockOnlyDuringDimming")] = false;
+    doc[F("buzzerEnabled")] = false;
+    doc[F("buttonEnabled")] = false;
+    doc[F("buttonShortPressAction")] = "next_mode";
+    doc[F("buttonLongPressAction")]  = "display_off";
 
     // Add countdown defaults when creating a new config.json
     JsonObject countdownObj = doc.createNestedObject("countdown");
@@ -435,6 +446,10 @@ void loadConfig() {
   showHumidity = doc["showHumidity"] | false;
   colonBlinkEnabled = doc.containsKey("colonBlinkEnabled") ? doc["colonBlinkEnabled"].as<bool>() : true;
   showWeatherDescription = doc["showWeatherDescription"] | false;
+  buzzerEnabled = doc["buzzerEnabled"] | false;
+  buttonEnabled = doc["buttonEnabled"] | false;
+  buttonShortPressAction = doc["buttonShortPressAction"] | String("next_mode");
+  buttonLongPressAction  = doc["buttonLongPressAction"]  | String("display_off");
 
   // --- Dimming settings ---
   if (doc["dimmingEnabled"].is<bool>()) {
@@ -840,6 +855,11 @@ void printConfigToSerial() {
   Serial.println(isDramaticCountdown ? "Yes" : "No");
   Serial.print(F("Custom Message: "));
   Serial.println(customMessage);
+  Serial.print(F("Buzzer Pin (GPIO): "));
+  if (BUZZER_PIN >= 0) Serial.println(BUZZER_PIN);
+  else Serial.println(F("Not configured"));
+  Serial.print(F("Buzzer Sound: "));
+  Serial.println(buzzerEnabled ? "Enabled" : "Disabled");
 
   Serial.print(F("Total Runtime: "));
   if (getTotalRuntimeSeconds() > 0) {
@@ -1280,6 +1300,10 @@ void setupWebServer() {
         if (v == "Off" || v == "off") doc[n] = -1;
         else doc[n] = v.toInt();
       } else if (n == "showWeatherDescription") doc[n] = (v == "true" || v == "on" || v == "1");
+      else if (n == "buzzerEnabled") doc[n] = (v == "true" || v == "on" || v == "1");
+      else if (n == "buttonEnabled") doc[n] = (v == "true" || v == "on" || v == "1");
+      else if (n == "buttonShortPressAction") doc[n] = v;
+      else if (n == "buttonLongPressAction")  doc[n] = v;
       else if (n == "dimmingEnabled") doc[n] = (v == "true" || v == "on" || v == "1");
       else if (n == "clockOnlyDuringDimming") {
         doc[n] = (v == "true" || v == "on" || v == "1");
@@ -1511,6 +1535,50 @@ void setupWebServer() {
   server.on("/set_countdown_enabled", HTTP_POST, setHandler);
   server.on("/set_dramatic_countdown", HTTP_POST, setHandler);
   server.on("/set_clock_only_dimming", HTTP_POST, setHandler);
+  server.on("/set_buzzer", HTTP_POST, setHandler);
+  server.on("/set_button", HTTP_POST, setHandler);
+  server.on(
+    "/save_button_actions", HTTP_POST, [](AsyncWebServerRequest *request) {
+      if (request->hasParam("shortPress", true))
+        buttonShortPressAction = request->getParam("shortPress", true)->value();
+      if (request->hasParam("longPress", true))
+        buttonLongPressAction = request->getParam("longPress", true)->value();
+      configDirty = true;
+      request->send(200, "application/json", "{\"ok\":true}");
+    },
+    NULL, [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {});
+
+  // --- Pin Configuration Endpoints ---
+  server.on("/get_pins", HTTP_GET, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(128);
+    doc["clk"]    = CLK_PIN;
+    doc["cs"]     = CS_PIN;
+    doc["data"]   = DATA_PIN;
+    doc["buzzer"] = BUZZER_PIN;
+    doc["button"] = BUTTON_PIN;
+    String response;
+    serializeJson(doc, response);
+    request->send(200, "application/json", response);
+  });
+
+  server.on(
+    "/save_pins", HTTP_POST, [](AsyncWebServerRequest *request) {
+      prefs.begin("pins", false);
+      if (request->hasParam("clk", true))    prefs.putInt("clk",    request->getParam("clk",    true)->value().toInt());
+      if (request->hasParam("cs", true))     prefs.putInt("cs",     request->getParam("cs",     true)->value().toInt());
+      if (request->hasParam("data", true))   prefs.putInt("data",   request->getParam("data",   true)->value().toInt());
+      if (request->hasParam("buzzer", true)) prefs.putInt("buzzer", request->getParam("buzzer", true)->value().toInt());
+      if (request->hasParam("button", true)) prefs.putInt("button", request->getParam("button", true)->value().toInt());
+      prefs.end();
+      Serial.println(F("[PINS] Pin config saved to NVS — rebooting"));
+      request->send(200, "application/json", "{\"ok\":true}");
+      request->onDisconnect([]() {
+        saveUptime();
+        delay(100);
+        ESP.restart();
+      });
+    },
+    NULL, [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {});
 
   // --- Custom Message Endpoint ---
   server.on("/set_custom_message", HTTP_ANY, [](AsyncWebServerRequest *request) {
@@ -1554,7 +1622,14 @@ void setupWebServer() {
       } else {
         // Handle other actions (brightness, etc.)
         if (request->params() > 0) {
-          executeAction(request->getParam(0)->name(), request->getParam(0)->value());
+          String actionName = request->getParam(0)->name();
+          if (actionName == "buzzer_beep") {
+            int freq       = request->hasArg("freq")       ? request->arg("freq").toInt()       : 2000;
+            int durationMs = request->hasArg("durationMs") ? request->arg("durationMs").toInt() : 150;
+            buzzerBeep(freq, durationMs);
+          } else {
+            executeAction(actionName, request->getParam(0)->value());
+          }
           request->send(200, "text/plain", "OK");
         } else {
           request->send(400, "text/plain", "No parameters found");
@@ -1700,6 +1775,12 @@ void setupWebServer() {
     doc["message"] = (strlen(customMessage) > 0) ? customMessage : "";
     doc["displayOff"] = displayOff;
     doc["brightness"] = brightness;
+    doc["buzzerEnabled"] = buzzerEnabled;
+    doc["buzzerPin"] = BUZZER_PIN;
+    doc["buttonEnabled"] = buttonEnabled;
+    doc["buttonPin"] = BUTTON_PIN;
+    doc["buttonShortPressAction"] = buttonShortPressAction;
+    doc["buttonLongPressAction"]  = buttonLongPressAction;
 
     // --- Runtime ---
     doc["device_runtime"] = formatTotalRuntime();
@@ -2974,6 +3055,26 @@ void executeAction(const String &action, const String &value) {
     clockOnlyDuringDimming = hasValue ? boolVal : !clockOnlyDuringDimming;
     configDirty = true;
 
+  } else if (action == "buzzer") {
+    buzzerEnabled = hasValue ? boolVal : !buzzerEnabled;
+    configDirty = true;
+    if (buzzerEnabled && BUZZER_PIN >= 0) {
+      buzzerBeep(2000, 150);  // confirmation beep
+    }
+
+  } else if (action == "buzzer_test") {
+    buzzerTestBeep();
+
+  } else if (action == "buzzer_stop") {
+    buzzerEnabled = false;
+    if (BUZZER_PIN >= 0) ledcWrite(BUZZER_PIN, 0);
+    configDirty = true;
+
+  } else if (action == "button") {
+    buttonEnabled = hasValue ? boolVal : !buttonEnabled;
+    if (buttonEnabled && BUTTON_PIN >= 0) pinMode(BUTTON_PIN, INPUT_PULLUP);
+    configDirty = true;
+
   } else if (action == "go_to_mode") {
     goToMode(value);
 
@@ -3147,6 +3248,46 @@ void goToMode(const String &target) {
   lastSwitch = millis();
 }
 
+// -----------------------------------------------------------------------------
+// Passive Buzzer (KY-006) — LEDC PWM driver (ESP32 Arduino core v3.x API)
+// -----------------------------------------------------------------------------
+#define BUZZER_LEDC_RESOLUTION 8   // 8-bit, 0-255
+
+void buzzerInit() {
+  if (BUZZER_PIN < 0) return;
+  // v3.x: ledcAttach(pin, freq, resolution) — channel assigned automatically
+  ledcAttach(BUZZER_PIN, 2000, BUZZER_LEDC_RESOLUTION);
+  ledcWrite(BUZZER_PIN, 0);  // silent at startup
+  Serial.printf("[BUZZER] Initialized on GPIO %d (sound %s)\n", BUZZER_PIN, buzzerEnabled ? "enabled" : "disabled");
+}
+
+// Blocking beep — respects buzzerEnabled flag
+void buzzerBeep(int freq, int durationMs) {
+  if (BUZZER_PIN < 0 || !buzzerEnabled) return;
+  ledcWriteTone(BUZZER_PIN, freq);
+  delay(durationMs);
+  ledcWrite(BUZZER_PIN, 0);
+}
+
+// Test beep — always plays regardless of buzzerEnabled (used from web UI)
+void buzzerTestBeep() {
+  if (BUZZER_PIN < 0) return;
+  ledcWriteTone(BUZZER_PIN, 2000); delay(200);
+  ledcWrite(BUZZER_PIN, 0);        delay(80);
+  ledcWriteTone(BUZZER_PIN, 2500); delay(150);
+  ledcWrite(BUZZER_PIN, 0);
+}
+
+// Three-beep alert sequence (countdown / timer finish)
+void buzzerAlert() {
+  if (BUZZER_PIN < 0 || !buzzerEnabled) return;
+  for (int i = 0; i < 3; i++) {
+    ledcWriteTone(BUZZER_PIN, 2000); delay(150);
+    ledcWrite(BUZZER_PIN, 0);        delay(100);
+  }
+}
+
+
 void loadPins() {
   prefs.begin("pins", false);
 
@@ -3171,6 +3312,8 @@ void loadPins() {
   CLK_PIN  = prefs.getInt("clk", L_CLK);
   CS_PIN   = prefs.getInt("cs", L_CS);
   DATA_PIN = prefs.getInt("data", L_DATA);
+  BUZZER_PIN = prefs.getInt("buzzer", -1);  // -1 = not configured
+  BUTTON_PIN = prefs.getInt("button", -1);  // -1 = not configured
 
   // Validation + fallback (optional improvement below 👇)
   if (CLK_PIN < 0 || CS_PIN < 0 || DATA_PIN < 0) {
@@ -3181,42 +3324,41 @@ void loadPins() {
     DATA_PIN = L_DATA;
   }
 
-  Serial.printf("[PIN CONFIG] Loaded pins - CLK:%d CS:%d DATA:%d\n", CLK_PIN, CS_PIN, DATA_PIN);
+  Serial.printf("[PIN CONFIG] Loaded pins - CLK:%d CS:%d DATA:%d Buzzer:%d Button:%d\n", CLK_PIN, CS_PIN, DATA_PIN, BUZZER_PIN, BUTTON_PIN);
 }
 
 
 // =============================================================================
-// PHYSICAL BUTTON TEMPLATE
-// To enable: uncomment ALL lines below, and set BUTTON_PIN to your GPIO pin.
+// PHYSICAL BUTTON
+// Configured via web UI: enable/disable + GPIO pin stored in NVS.
+// Short press: next mode. Long press (800ms): toggle display off.
 // =============================================================================
 
-// #define BUTTON_PIN 4               // ← Change to your GPIO pin
-// #define BUTTON_LONG_PRESS_MS 800   // ← Hold duration for long press (ms)
-
-// void handleButton() {
-//   static unsigned long lastPress = 0;
-//   static unsigned long pressStart = 0;
-//   static bool lastState = HIGH;
-//   static bool longPressHandled = false;
-//   bool currentState = digitalRead(BUTTON_PIN);
-//   if (currentState == LOW && lastState == HIGH) {
-//     pressStart = millis();
-//     longPressHandled = false;
-//   }
-//   if (currentState == LOW && !longPressHandled) {
-//     if (millis() - pressStart >= BUTTON_LONG_PRESS_MS) {
-//       longPressHandled = true;
-//       executeAction("display_off", "");   // ← LONG PRESS action
-//     }
-//   }
-//   if (currentState == HIGH && lastState == LOW) {
-//     if (!longPressHandled && millis() - lastPress > 200) {
-//       lastPress = millis();
-//       executeAction("next_mode", "");     // ← SHORT PRESS action
-//     }
-//   }
-//   lastState = currentState;
-// }
+void handleButton() {
+  if (!buttonEnabled || BUTTON_PIN < 0) return;
+  static unsigned long lastPress = 0;
+  static unsigned long pressStart = 0;
+  static bool lastState = HIGH;
+  static bool longPressHandled = false;
+  bool currentState = digitalRead(BUTTON_PIN);
+  if (currentState == LOW && lastState == HIGH) {
+    pressStart = millis();
+    longPressHandled = false;
+  }
+  if (currentState == LOW && !longPressHandled) {
+    if (millis() - pressStart >= BUTTON_LONG_PRESS_MS) {
+      longPressHandled = true;
+      executeAction(buttonLongPressAction, "");
+    }
+  }
+  if (currentState == HIGH && lastState == LOW) {
+    if (!longPressHandled && millis() - lastPress > 200) {
+      lastPress = millis();
+      executeAction(buttonShortPressAction, "");
+    }
+  }
+  lastState = currentState;
+}
 
 
 // -----------------------------------------------------------------------------
@@ -3233,7 +3375,7 @@ DisplayMode key:
   6: Custom Message
 */
 void setup() {
-  // pinMode(BUTTON_PIN, INPUT_PULLUP);  // ← Uncomment if using button
+  if (buttonEnabled && BUTTON_PIN >= 0) pinMode(BUTTON_PIN, INPUT_PULLUP);
 
   Serial.begin(115200);
   delay(1000);
@@ -3260,7 +3402,8 @@ void setup() {
   P.begin();
   P.setCharSpacing(0);
   P.setFont(mFactory);
-  loadConfig(); 
+  loadConfig();
+  buzzerInit();
   P.setIntensity(brightness);
   if (displayOff) {
     P.displayShutdown(true);
@@ -3577,6 +3720,10 @@ bool saveConfigRuntime() {
   doc["showHumidity"] = showHumidity;
   doc["colonBlinkEnabled"] = colonBlinkEnabled;
   doc["clockOnlyDuringDimming"] = clockOnlyDuringDimming;
+  doc["buzzerEnabled"] = buzzerEnabled;
+  doc["buttonEnabled"] = buttonEnabled;
+  doc["buttonShortPressAction"] = buttonShortPressAction;
+  doc["buttonLongPressAction"]  = buttonLongPressAction;
 
   File configFileWrite = LittleFS.open("/config.json", "w");
   if (!configFileWrite) {
@@ -3632,7 +3779,7 @@ String getFormattedDateText(const char *rawText) {
 }
 
 void loop() {
-  // handleButton();  // ← Uncomment if using button
+  handleButton();
 
   // --- WIFI RECONNECTION ---
   static unsigned long lastReconnectAttempt = 0;
@@ -4261,7 +4408,8 @@ void loop() {
         countdownShowFinishedMessage = true;           // Confirm we are in the finished sequence
         countdownFinishedMessageStartTime = millis();  // Start the 15-second timer for the flashing duration
 
-        // 1. Play Hourglass Animation (Blocking)
+        // 1. Play alert beeps then hourglass animation (blocking)
+        buzzerAlert();
         const char *hourglassFrames[] = { "¡", "¢", "£", "¤" };
         for (int repeat = 0; repeat < 3; repeat++) {
           for (int i = 0; i < 4; i++) {
@@ -4896,6 +5044,7 @@ void showTimerMode7() {
       if (now >= timerEndTime) {
         timerFinished = true;
         timerFinishStartTime = now;
+        buzzerAlert();
       } else {
         remaining = (long)((timerEndTime - now) / 1000);
         if (remaining < 0) remaining = 0;

--- a/ESPTimeCast_ESP32/index_html.h
+++ b/ESPTimeCast_ESP32/index_html.h
@@ -1496,6 +1496,142 @@ const char index_html[] PROGMEM = R"rawliteral(
           class="sub-collapsible active"
           aria-expanded="false"
         >
+          Buzzer
+        </button>
+        <div class="sub-collapsible-content" aria-hidden="true">
+          <div class="content-wrapper">
+            <div class="toggle-padding">
+              <label class="toggle-row-lg">
+                <span class="label-text">Enable Sound:</span>
+                <span class="toggle-switch">
+                  <input
+                    type="checkbox"
+                    id="buzzerEnabled"
+                    name="buzzerEnabled"
+                    onchange="setBuzzerEnabled(this.checked)"
+                  />
+                  <span class="toggle-slider"></span>
+                </span>
+              </label>
+            </div>
+
+            <label for="buzzerPin">Signal GPIO Pin:</label>
+            <select id="buzzerPin" name="buzzerPin">
+              <option value="-1">— Not configured —</option>
+              <option value="1">GPIO 1</option>
+              <option value="2">GPIO 2</option>
+              <option value="4">GPIO 4</option>
+              <option value="5">GPIO 5</option>
+              <option value="6">GPIO 6</option>
+              <option value="7">GPIO 7</option>
+              <option value="8">GPIO 8</option>
+              <option value="15">GPIO 15</option>
+              <option value="16">GPIO 16</option>
+              <option value="17">GPIO 17</option>
+              <option value="18">GPIO 18</option>
+            </select>
+            <div class="small">
+              Connect KY-006 S → GPIO, GND → GND, + → 3.3V.
+              Changing the pin requires a reboot.
+            </div>
+
+            <div class="form-row two-col" style="margin-top:0.75rem">
+              <button type="button" class="primary-button" onclick="saveBuzzerPin()">
+                Save Pin &amp; Reboot
+              </button>
+              <button type="button" class="primary-button" onclick="testBuzzer()">
+                Test Buzzer
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="sub-collapsible active"
+          aria-expanded="false"
+        >
+          Physical Button
+        </button>
+        <div class="sub-collapsible-content" aria-hidden="true">
+          <div class="content-wrapper">
+            <div class="toggle-padding">
+              <label class="toggle-row-lg">
+                <span class="label-text">Enable Button:</span>
+                <span class="toggle-switch">
+                  <input
+                    type="checkbox"
+                    id="buttonEnabled"
+                    name="buttonEnabled"
+                    onchange="setButtonEnabled(this.checked)"
+                  />
+                  <span class="toggle-slider"></span>
+                </span>
+              </label>
+            </div>
+
+            <label for="buttonPin">Signal GPIO Pin:</label>
+            <select id="buttonPin" name="buttonPin">
+              <option value="-1">— Not configured —</option>
+              <option value="1">GPIO 1</option>
+              <option value="2">GPIO 2</option>
+              <option value="4">GPIO 4</option>
+              <option value="5">GPIO 5</option>
+              <option value="6">GPIO 6</option>
+              <option value="7">GPIO 7</option>
+              <option value="8">GPIO 8</option>
+              <option value="15">GPIO 15</option>
+              <option value="16">GPIO 16</option>
+              <option value="17">GPIO 17</option>
+              <option value="18">GPIO 18</option>
+            </select>
+            <div class="small">
+              Connect button between GPIO and GND (INPUT_PULLUP).
+              Changing the pin requires a reboot. Actions take effect immediately.
+            </div>
+
+            <label for="buttonShortPress" style="margin-top:0.75rem">Short Press Action:</label>
+            <select id="buttonShortPress" name="buttonShortPress">
+              <option value="next_mode">Next display mode</option>
+              <option value="prev_mode">Previous display mode</option>
+              <option value="display_off">Toggle display on/off</option>
+              <option value="brightness_up">Increase brightness</option>
+              <option value="brightness_down">Decrease brightness</option>
+              <option value="enable_rotation">Toggle auto-rotation</option>
+              <option value="buzzer_beep">Play a beep</option>
+              <option value="buzzer_stop">Stop buzzer</option>
+              <option value="restart">Reboot device</option>
+            </select>
+
+            <label for="buttonLongPress">Long Press Action (800ms):</label>
+            <select id="buttonLongPress" name="buttonLongPress">
+              <option value="next_mode">Next display mode</option>
+              <option value="prev_mode">Previous display mode</option>
+              <option value="display_off">Toggle display on/off</option>
+              <option value="brightness_up">Increase brightness</option>
+              <option value="brightness_down">Decrease brightness</option>
+              <option value="enable_rotation">Toggle auto-rotation</option>
+              <option value="buzzer_beep">Play a beep</option>
+              <option value="buzzer_stop">Stop buzzer</option>
+              <option value="restart">Reboot device</option>
+            </select>
+
+            <div class="form-row two-col" style="margin-top:0.75rem">
+              <button type="button" class="primary-button" onclick="saveButtonActions()">
+                Save Actions
+              </button>
+              <button type="button" class="primary-button" onclick="saveButtonPin()">
+                Save Pin &amp; Reboot
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="sub-collapsible active"
+          aria-expanded="false"
+        >
           Device information
         </button>
         <div class="sub-collapsible-content" aria-hidden="true">
@@ -1552,7 +1688,7 @@ const char index_html[] PROGMEM = R"rawliteral(
       <input type="submit" class="primary-button" value="Save Settings" />
     </form>
 
-    <div class="footer">      
+    <div class="footer">
       <a href="https://esptimecast.github.io" target="_blank" rel="noopener noreferrer">
       ESPTimeCast<span class="tm">™</span> by M-Factory</a>
     </div>
@@ -1675,6 +1811,23 @@ const char index_html[] PROGMEM = R"rawliteral(
               !!data.colonBlinkEnabled;
             document.getElementById("showWeatherDescription").checked =
               !!data.showWeatherDescription;
+            document.getElementById("buzzerEnabled").checked =
+              !!data.buzzerEnabled;
+            document.getElementById("buttonEnabled").checked =
+              !!data.buttonEnabled;
+            if (data.buttonShortPressAction) document.getElementById("buttonShortPress").value = data.buttonShortPressAction;
+            if (data.buttonLongPressAction)  document.getElementById("buttonLongPress").value  = data.buttonLongPressAction;
+
+            // --- Buzzer + Button Pins (from NVS via /get_pins) ---
+            fetch("/get_pins")
+              .then((r) => r.json())
+              .then((pins) => {
+                const sel = document.getElementById("buzzerPin");
+                if (pins.buzzer !== undefined) sel.value = String(pins.buzzer);
+                const btnSel = document.getElementById("buttonPin");
+                if (pins.button !== undefined) btnSel.value = String(pins.button);
+              })
+              .catch(() => {});
 
             // --- Dimming Controls ---
             const autoDimmingEl = document.getElementById("autoDimmingEnabled");
@@ -1967,6 +2120,16 @@ const char index_html[] PROGMEM = R"rawliteral(
           "showWeatherDescription",
           document.getElementById("showWeatherDescription").checked ? "on" : "",
         );
+        formData.set(
+          "buzzerEnabled",
+          document.getElementById("buzzerEnabled").checked ? "on" : "",
+        );
+        formData.set(
+          "buttonEnabled",
+          document.getElementById("buttonEnabled").checked ? "on" : "",
+        );
+        formData.set("buttonShortPressAction", document.getElementById("buttonShortPress").value);
+        formData.set("buttonLongPressAction",  document.getElementById("buttonLongPress").value);
         formData.set(
           "weatherUnits",
           document.getElementById("weatherUnits").checked
@@ -2459,6 +2622,72 @@ const char index_html[] PROGMEM = R"rawliteral(
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
           body: "value=" + (val ? 1 : 0),
         });
+      }
+
+      // --- Buzzer ---
+      function setBuzzerEnabled(val) {
+        fetch("/set_buzzer", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "value=" + (val ? 1 : 0),
+        });
+      }
+
+      function saveBuzzerPin() {
+        const pin = document.getElementById("buzzerPin").value;
+        fetch("/save_pins", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "buzzer=" + encodeURIComponent(pin),
+        })
+          .then((r) => r.json())
+          .then(() => {
+            alert("Buzzer pin saved. Device will reboot...");
+          })
+          .catch((e) => console.error("save_pins failed:", e));
+      }
+
+      function testBuzzer() {
+        fetch("/action", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "buzzer_test=1",
+        });
+      }
+
+      // --- Physical Button ---
+      function setButtonEnabled(val) {
+        fetch("/set_button", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "value=" + (val ? 1 : 0),
+        });
+      }
+
+      function saveButtonPin() {
+        const pin = document.getElementById("buttonPin").value;
+        fetch("/save_pins", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "button=" + encodeURIComponent(pin),
+        })
+          .then((r) => r.json())
+          .then(() => {
+            alert("Button pin saved. Device will reboot...");
+          })
+          .catch((e) => console.error("save_pins failed:", e));
+      }
+
+      function saveButtonActions() {
+        fetch("/save_button_actions", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "shortPress=" + encodeURIComponent(document.getElementById("buttonShortPress").value)
+              + "&longPress=" + encodeURIComponent(document.getElementById("buttonLongPress").value),
+        })
+          .then((r) => r.json())
+          .then(() => { alert("Button actions saved."); })
+          .catch((e) => console.error("save_button_actions failed:", e));
       }
 
       // --- Clock-only-during-dimming setter (no reboot) ---

--- a/ESPTimeCast_ESP8266/ESPTimeCast_ESP8266.ino
+++ b/ESPTimeCast_ESP8266/ESPTimeCast_ESP8266.ino
@@ -38,6 +38,14 @@ See LICENSE.txt for full terms.
 #define CS_PIN 13    //D7
 #define DATA_PIN 15  //D8
 
+int  buzzerPin     = -1;   // -1 = not configured (stored in config.json)
+bool buzzerEnabled = false;
+int  buttonPin     = -1;   // -1 = not configured (stored in config.json)
+bool buttonEnabled = false;
+String buttonShortPressAction = "next_mode";
+String buttonLongPressAction  = "display_off";
+#define BUTTON_LONG_PRESS_MS 800
+
 #ifdef ESP8266
 WiFiEventHandler mConnectHandler;
 WiFiEventHandler mDisConnectHandler;
@@ -291,6 +299,42 @@ textEffect_t getEffectiveScrollDirection(textEffect_t desiredDirection, bool isF
 // -----------------------------------------------------------------------------
 // Configuration Load & Save
 // -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+// Passive Buzzer (KY-006) — tone() driver (ESP8266 has no LEDC)
+// -----------------------------------------------------------------------------
+
+void buzzerInit() {
+  if (buzzerPin < 0) return;
+  pinMode(buzzerPin, OUTPUT);
+  noTone(buzzerPin);
+  Serial.printf("[BUZZER] Initialized on GPIO %d (sound %s)\n", buzzerPin, buzzerEnabled ? "enabled" : "disabled");
+}
+
+// Blocking beep — respects buzzerEnabled flag
+void buzzerBeep(int freq, int durationMs) {
+  if (buzzerPin < 0 || !buzzerEnabled) return;
+  tone(buzzerPin, freq);
+  delay(durationMs);
+  noTone(buzzerPin);
+}
+
+// Test beep — always plays regardless of buzzerEnabled (used from web UI)
+void buzzerTestBeep() {
+  if (buzzerPin < 0) return;
+  tone(buzzerPin, 2000); delay(200); noTone(buzzerPin);
+  delay(80);
+  tone(buzzerPin, 2500); delay(150); noTone(buzzerPin);
+}
+
+// Three-beep alert sequence (countdown / timer finish)
+void buzzerAlert() {
+  if (buzzerPin < 0 || !buzzerEnabled) return;
+  for (int i = 0; i < 3; i++) {
+    tone(buzzerPin, 2000); delay(150); noTone(buzzerPin); delay(100);
+  }
+}
+
+
 void loadConfig() {
   Serial.println(F("[CONFIG] Loading configuration..."));
 
@@ -332,6 +376,13 @@ void loadConfig() {
     doc[F("sunsetHour")] = sunsetHour;
     doc[F("sunsetMinute")] = sunsetMinute;
     doc[F("clockOnlyDuringDimming")] = false;
+
+    doc[F("buzzerPin")]     = -1;
+    doc[F("buzzerEnabled")] = false;
+    doc[F("buttonPin")]     = -1;
+    doc[F("buttonEnabled")] = false;
+    doc[F("buttonShortPressAction")] = "next_mode";
+    doc[F("buttonLongPressAction")]  = "display_off";
 
     // Add countdown defaults when creating a new config.json
     JsonObject countdownObj = doc.createNestedObject("countdown");
@@ -402,6 +453,12 @@ void loadConfig() {
   showHumidity = doc["showHumidity"] | false;
   colonBlinkEnabled = doc.containsKey("colonBlinkEnabled") ? doc["colonBlinkEnabled"].as<bool>() : true;
   showWeatherDescription = doc["showWeatherDescription"] | false;
+  buzzerPin     = doc["buzzerPin"]     | -1;
+  buzzerEnabled = doc["buzzerEnabled"] | false;
+  buttonPin     = doc["buttonPin"]     | -1;
+  buttonEnabled = doc["buttonEnabled"] | false;
+  buttonShortPressAction = doc["buttonShortPressAction"] | String("next_mode");
+  buttonLongPressAction  = doc["buttonLongPressAction"]  | String("display_off");
 
   // --- Dimming settings ---
   if (doc["dimmingEnabled"].is<bool>()) {
@@ -805,6 +862,11 @@ void printConfigToSerial() {
   Serial.println(isDramaticCountdown ? "Yes" : "No");
   Serial.print(F("Custom Message: "));
   Serial.println(customMessage);
+  Serial.print(F("Buzzer Pin (GPIO): "));
+  if (buzzerPin >= 0) Serial.println(buzzerPin);
+  else Serial.println(F("Not configured"));
+  Serial.print(F("Buzzer Sound: "));
+  Serial.println(buzzerEnabled ? "Enabled" : "Disabled");
 
   Serial.print(F("Total Runtime: "));
   if (getTotalRuntimeSeconds() > 0) {
@@ -1245,6 +1307,12 @@ void setupWebServer() {
         if (v == "Off" || v == "off") doc[n] = -1;
         else doc[n] = v.toInt();
       } else if (n == "showWeatherDescription") doc[n] = (v == "true" || v == "on" || v == "1");
+      else if (n == "buzzerEnabled") doc[n] = (v == "true" || v == "on" || v == "1");
+      else if (n == "buzzerPin") doc[n] = v.toInt();
+      else if (n == "buttonEnabled") doc[n] = (v == "true" || v == "on" || v == "1");
+      else if (n == "buttonPin") doc[n] = v.toInt();
+      else if (n == "buttonShortPressAction") doc[n] = v;
+      else if (n == "buttonLongPressAction")  doc[n] = v;
       else if (n == "dimmingEnabled") doc[n] = (v == "true" || v == "on" || v == "1");
       else if (n == "clockOnlyDuringDimming") {
         doc[n] = (v == "true" || v == "on" || v == "1");
@@ -1476,6 +1544,66 @@ void setupWebServer() {
   server.on("/set_countdown_enabled", HTTP_POST, setHandler);
   server.on("/set_dramatic_countdown", HTTP_POST, setHandler);
   server.on("/set_clock_only_dimming", HTTP_POST, setHandler);
+  server.on("/set_buzzer", HTTP_POST, setHandler);
+  server.on("/set_button", HTTP_POST, setHandler);
+  server.on(
+    "/save_button_actions", HTTP_POST, [](AsyncWebServerRequest *request) {
+      if (request->hasParam("shortPress", true))
+        buttonShortPressAction = request->getParam("shortPress", true)->value();
+      if (request->hasParam("longPress", true))
+        buttonLongPressAction = request->getParam("longPress", true)->value();
+      configDirty = true;
+      request->send(200, "application/json", "{\"ok\":true}");
+    },
+    NULL, [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {});
+
+  // --- Pin info & buzzer pin save ---
+  server.on("/get_pins", HTTP_GET, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(128);
+    doc["clk"]    = CLK_PIN;
+    doc["cs"]     = CS_PIN;
+    doc["data"]   = DATA_PIN;
+    doc["buzzer"] = buzzerPin;
+    doc["button"] = buttonPin;
+    String response;
+    serializeJson(doc, response);
+    request->send(200, "application/json", response);
+  });
+
+  server.on(
+    "/save_pins", HTTP_POST, [](AsyncWebServerRequest *request) {
+      bool pinChanged = false;
+      if (request->hasParam("buzzer", true) || request->hasParam("button", true)) {
+        File f = LittleFS.open("/config.json", "r");
+        if (f) {
+          DynamicJsonDocument doc(2048);
+          if (!deserializeJson(doc, f)) {
+            f.close();
+            if (request->hasParam("buzzer", true)) {
+              int newPin = request->getParam("buzzer", true)->value().toInt();
+              doc["buzzerPin"] = newPin;
+              Serial.printf("[PINS] Buzzer pin saved to GPIO %d\n", newPin);
+            }
+            if (request->hasParam("button", true)) {
+              int newPin = request->getParam("button", true)->value().toInt();
+              doc["buttonPin"] = newPin;
+              Serial.printf("[PINS] Button pin saved to GPIO %d\n", newPin);
+            }
+            File w = LittleFS.open("/config.json", "w");
+            if (w) { serializeJson(doc, w); w.close(); }
+            pinChanged = true;
+          } else { f.close(); }
+        }
+      }
+      if (pinChanged) Serial.println(F("[PINS] Pin config saved — rebooting"));
+      request->send(200, "application/json", "{\"ok\":true}");
+      request->onDisconnect([]() {
+        saveUptime();
+        delay(100);
+        ESP.restart();
+      });
+    },
+    NULL, [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {});
 
   // --- Custom Message Endpoint ---
   server.on("/set_custom_message", HTTP_ANY, [](AsyncWebServerRequest *request) {
@@ -1519,7 +1647,14 @@ void setupWebServer() {
       } else {
         // Handle other actions (brightness, etc.)
         if (request->params() > 0) {
-          executeAction(request->getParam(0)->name(), request->getParam(0)->value());
+          String actionName = request->getParam(0)->name();
+          if (actionName == "buzzer_beep") {
+            int freq       = request->hasArg("freq")       ? request->arg("freq").toInt()       : 2000;
+            int durationMs = request->hasArg("durationMs") ? request->arg("durationMs").toInt() : 150;
+            buzzerBeep(freq, durationMs);
+          } else {
+            executeAction(actionName, request->getParam(0)->value());
+          }
           request->send(200, "text/plain", "OK");
         } else {
           request->send(400, "text/plain", "No parameters found");
@@ -1636,6 +1771,12 @@ void setupWebServer() {
     doc["message"] = (strlen(customMessage) > 0) ? customMessage : "";
     doc["displayOff"] = displayOff;
     doc["brightness"] = brightness;
+    doc["buzzerEnabled"] = buzzerEnabled;
+    doc["buzzerPin"] = buzzerPin;
+    doc["buttonEnabled"] = buttonEnabled;
+    doc["buttonPin"] = buttonPin;
+    doc["buttonShortPressAction"] = buttonShortPressAction;
+    doc["buttonLongPressAction"]  = buttonLongPressAction;
 
     // --- Runtime ---
     doc["device_runtime"] = formatTotalRuntime();
@@ -2912,6 +3053,26 @@ void executeAction(const String &action, const String &value) {
     clockOnlyDuringDimming = hasValue ? boolVal : !clockOnlyDuringDimming;
     configDirty = true;
 
+  } else if (action == "buzzer") {
+    buzzerEnabled = hasValue ? boolVal : !buzzerEnabled;
+    configDirty = true;
+    if (buzzerEnabled && buzzerPin >= 0) {
+      buzzerBeep(2000, 150);  // confirmation beep
+    }
+
+  } else if (action == "buzzer_test") {
+    buzzerTestBeep();
+
+  } else if (action == "buzzer_stop") {
+    buzzerEnabled = false;
+    if (buzzerPin >= 0) noTone(buzzerPin);
+    configDirty = true;
+
+  } else if (action == "button") {
+    buttonEnabled = hasValue ? boolVal : !buttonEnabled;
+    if (buttonEnabled && buttonPin >= 0) pinMode(buttonPin, INPUT_PULLUP);
+    configDirty = true;
+
   } else if (action == "go_to_mode") {
     goToMode(value);
 
@@ -3087,37 +3248,36 @@ void goToMode(const String &target) {
 
 
 // =============================================================================
-// PHYSICAL BUTTON TEMPLATE
-// To enable: uncomment ALL lines below, and set BUTTON_PIN to your GPIO pin.
+// PHYSICAL BUTTON
+// Configured via web UI: enable/disable + GPIO pin stored in config.json.
+// Short press: next mode. Long press (800ms): toggle display off.
 // =============================================================================
 
-// #define BUTTON_PIN 4               // ← Change to your GPIO pin
-// #define BUTTON_LONG_PRESS_MS 800   // ← Hold duration for long press (ms)
-
-// void handleButton() {
-//   static unsigned long lastPress = 0;
-//   static unsigned long pressStart = 0;
-//   static bool lastState = HIGH;
-//   static bool longPressHandled = false;
-//   bool currentState = digitalRead(BUTTON_PIN);
-//   if (currentState == LOW && lastState == HIGH) {
-//     pressStart = millis();
-//     longPressHandled = false;
-//   }
-//   if (currentState == LOW && !longPressHandled) {
-//     if (millis() - pressStart >= BUTTON_LONG_PRESS_MS) {
-//       longPressHandled = true;
-//       executeAction("display_off", "");   // ← LONG PRESS action
-//     }
-//   }
-//   if (currentState == HIGH && lastState == LOW) {
-//     if (!longPressHandled && millis() - lastPress > 200) {
-//       lastPress = millis();
-//       executeAction("next_mode", "");     // ← SHORT PRESS action
-//     }
-//   }
-//   lastState = currentState;
-// }
+void handleButton() {
+  if (!buttonEnabled || buttonPin < 0) return;
+  static unsigned long lastPress = 0;
+  static unsigned long pressStart = 0;
+  static bool lastState = HIGH;
+  static bool longPressHandled = false;
+  bool currentState = digitalRead(buttonPin);
+  if (currentState == LOW && lastState == HIGH) {
+    pressStart = millis();
+    longPressHandled = false;
+  }
+  if (currentState == LOW && !longPressHandled) {
+    if (millis() - pressStart >= BUTTON_LONG_PRESS_MS) {
+      longPressHandled = true;
+      executeAction(buttonLongPressAction, "");
+    }
+  }
+  if (currentState == HIGH && lastState == LOW) {
+    if (!longPressHandled && millis() - lastPress > 200) {
+      lastPress = millis();
+      executeAction(buttonShortPressAction, "");
+    }
+  }
+  lastState = currentState;
+}
 
 
 // -----------------------------------------------------------------------------
@@ -3134,7 +3294,7 @@ DisplayMode key:
   6: Custom Message
 */
 void setup() {
-  // pinMode(BUTTON_PIN, INPUT_PULLUP);  // ← Uncomment if using button
+  if (buttonEnabled && buttonPin >= 0) pinMode(buttonPin, INPUT_PULLUP);
   
   Serial.begin(115200);
   delay(1000);
@@ -3150,6 +3310,7 @@ void setup() {
   P.setCharSpacing(0);
   P.setFont(mFactory);
   loadConfig();
+  buzzerInit();
   P.setIntensity(brightness);
   if (displayOff) {
     P.displayShutdown(true);
@@ -3419,6 +3580,10 @@ bool saveConfigRuntime() {
   doc["showHumidity"] = showHumidity;
   doc["colonBlinkEnabled"] = colonBlinkEnabled;
   doc["clockOnlyDuringDimming"] = clockOnlyDuringDimming;
+  doc["buzzerEnabled"] = buzzerEnabled;
+  doc["buttonEnabled"] = buttonEnabled;
+  doc["buttonShortPressAction"] = buttonShortPressAction;
+  doc["buttonLongPressAction"]  = buttonLongPressAction;
 
   File configFileWrite = LittleFS.open("/config.json", "w");
   if (!configFileWrite) {
@@ -3474,7 +3639,7 @@ String getFormattedDateText(const char *rawText) {
 }
 
 void loop() {
-  // handleButton();  // ← Uncomment if using button
+  handleButton();
 
   // --- WIFI RECONNECTION ---
   static unsigned long lastReconnectAttempt = 0;
@@ -4105,7 +4270,8 @@ void loop() {
         countdownShowFinishedMessage = true;           // Confirm we are in the finished sequence
         countdownFinishedMessageStartTime = millis();  // Start the 15-second timer for the flashing duration
 
-        // 1. Play Hourglass Animation (Blocking)
+        // 1. Play alert beeps then hourglass animation (blocking)
+        buzzerAlert();
         const char *hourglassFrames[] = { "¡", "¢", "£", "¤" };
         for (int repeat = 0; repeat < 3; repeat++) {
           for (int i = 0; i < 4; i++) {
@@ -4740,6 +4906,7 @@ void showTimerMode7() {
       if (now >= timerEndTime) {
         timerFinished = true;
         timerFinishStartTime = now;
+        buzzerAlert();
       } else {
         remaining = (long)((timerEndTime - now) / 1000);
         if (remaining < 0) remaining = 0;

--- a/ESPTimeCast_ESP8266/index_html.h
+++ b/ESPTimeCast_ESP8266/index_html.h
@@ -1496,6 +1496,130 @@ const char index_html[] PROGMEM = R"rawliteral(
           class="sub-collapsible active"
           aria-expanded="false"
         >
+          Buzzer
+        </button>
+        <div class="sub-collapsible-content" aria-hidden="true">
+          <div class="content-wrapper">
+            <div class="toggle-padding">
+              <label class="toggle-row-lg">
+                <span class="label-text">Enable Sound:</span>
+                <span class="toggle-switch">
+                  <input
+                    type="checkbox"
+                    id="buzzerEnabled"
+                    name="buzzerEnabled"
+                    onchange="setBuzzerEnabled(this.checked)"
+                  />
+                  <span class="toggle-slider"></span>
+                </span>
+              </label>
+            </div>
+
+            <label for="buzzerPin">Signal GPIO Pin:</label>
+            <select id="buzzerPin" name="buzzerPin">
+              <option value="-1">— Not configured —</option>
+              <option value="4">GPIO 4 (D2)</option>
+              <option value="5">GPIO 5 (D1)</option>
+              <option value="12">GPIO 12 (D6)</option>
+            </select>
+            <div class="small">
+              Connect KY-006 S → GPIO, GND → GND, + → 3.3V.
+              Changing the pin requires a reboot.
+            </div>
+
+            <div class="form-row two-col" style="margin-top:0.75rem">
+              <button type="button" class="primary-button" onclick="saveBuzzerPin()">
+                Save Pin &amp; Reboot
+              </button>
+              <button type="button" class="primary-button" onclick="testBuzzer()">
+                Test Buzzer
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="sub-collapsible active"
+          aria-expanded="false"
+        >
+          Physical Button
+        </button>
+        <div class="sub-collapsible-content" aria-hidden="true">
+          <div class="content-wrapper">
+            <div class="toggle-padding">
+              <label class="toggle-row-lg">
+                <span class="label-text">Enable Button:</span>
+                <span class="toggle-switch">
+                  <input
+                    type="checkbox"
+                    id="buttonEnabled"
+                    name="buttonEnabled"
+                    onchange="setButtonEnabled(this.checked)"
+                  />
+                  <span class="toggle-slider"></span>
+                </span>
+              </label>
+            </div>
+
+            <label for="buttonPin">Signal GPIO Pin:</label>
+            <select id="buttonPin" name="buttonPin">
+              <option value="-1">— Not configured —</option>
+              <option value="0">GPIO 0 (D3)</option>
+              <option value="2">GPIO 2 (D4)</option>
+              <option value="4">GPIO 4 (D2)</option>
+              <option value="5">GPIO 5 (D1)</option>
+              <option value="12">GPIO 12 (D6)</option>
+              <option value="13">GPIO 13 (D7)</option>
+              <option value="16">GPIO 16 (D0)</option>
+            </select>
+            <div class="small">
+              ESP8266 safe GPIOs. Connect button between GPIO and GND (INPUT_PULLUP).
+              Changing the pin requires a reboot. Actions take effect immediately.
+            </div>
+
+            <label for="buttonShortPress" style="margin-top:0.75rem">Short Press Action:</label>
+            <select id="buttonShortPress" name="buttonShortPress">
+              <option value="next_mode">Next display mode</option>
+              <option value="prev_mode">Previous display mode</option>
+              <option value="display_off">Toggle display on/off</option>
+              <option value="brightness_up">Increase brightness</option>
+              <option value="brightness_down">Decrease brightness</option>
+              <option value="enable_rotation">Toggle auto-rotation</option>
+              <option value="buzzer_beep">Play a beep</option>
+              <option value="buzzer_stop">Stop buzzer</option>
+              <option value="restart">Reboot device</option>
+            </select>
+
+            <label for="buttonLongPress">Long Press Action (800ms):</label>
+            <select id="buttonLongPress" name="buttonLongPress">
+              <option value="next_mode">Next display mode</option>
+              <option value="prev_mode">Previous display mode</option>
+              <option value="display_off">Toggle display on/off</option>
+              <option value="brightness_up">Increase brightness</option>
+              <option value="brightness_down">Decrease brightness</option>
+              <option value="enable_rotation">Toggle auto-rotation</option>
+              <option value="buzzer_beep">Play a beep</option>
+              <option value="buzzer_stop">Stop buzzer</option>
+              <option value="restart">Reboot device</option>
+            </select>
+
+            <div class="form-row two-col" style="margin-top:0.75rem">
+              <button type="button" class="primary-button" onclick="saveButtonActions()">
+                Save Actions
+              </button>
+              <button type="button" class="primary-button" onclick="saveButtonPin()">
+                Save Pin &amp; Reboot
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="sub-collapsible active"
+          aria-expanded="false"
+        >
           Device information
         </button>
         <div class="sub-collapsible-content" aria-hidden="true">
@@ -1552,7 +1676,7 @@ const char index_html[] PROGMEM = R"rawliteral(
       <input type="submit" class="primary-button" value="Save Settings" />
     </form>
 
-    <div class="footer">      
+    <div class="footer">
       <a href="https://esptimecast.github.io" target="_blank" rel="noopener noreferrer">
       ESPTimeCast<span class="tm">™</span> by M-Factory</a>
     </div>
@@ -1675,6 +1799,23 @@ const char index_html[] PROGMEM = R"rawliteral(
               !!data.colonBlinkEnabled;
             document.getElementById("showWeatherDescription").checked =
               !!data.showWeatherDescription;
+            document.getElementById("buzzerEnabled").checked =
+              !!data.buzzerEnabled;
+            document.getElementById("buttonEnabled").checked =
+              !!data.buttonEnabled;
+            if (data.buttonShortPressAction) document.getElementById("buttonShortPress").value = data.buttonShortPressAction;
+            if (data.buttonLongPressAction)  document.getElementById("buttonLongPress").value  = data.buttonLongPressAction;
+
+            // --- Buzzer + Button Pins (from /get_pins) ---
+            fetch("/get_pins")
+              .then((r) => r.json())
+              .then((pins) => {
+                const sel = document.getElementById("buzzerPin");
+                if (pins.buzzer !== undefined) sel.value = String(pins.buzzer);
+                const btnSel = document.getElementById("buttonPin");
+                if (pins.button !== undefined) btnSel.value = String(pins.button);
+              })
+              .catch(() => {});
 
             // --- Dimming Controls ---
             const autoDimmingEl = document.getElementById("autoDimmingEnabled");
@@ -1967,6 +2108,16 @@ const char index_html[] PROGMEM = R"rawliteral(
           "showWeatherDescription",
           document.getElementById("showWeatherDescription").checked ? "on" : "",
         );
+        formData.set(
+          "buzzerEnabled",
+          document.getElementById("buzzerEnabled").checked ? "on" : "",
+        );
+        formData.set(
+          "buttonEnabled",
+          document.getElementById("buttonEnabled").checked ? "on" : "",
+        );
+        formData.set("buttonShortPressAction", document.getElementById("buttonShortPress").value);
+        formData.set("buttonLongPressAction",  document.getElementById("buttonLongPress").value);
         formData.set(
           "weatherUnits",
           document.getElementById("weatherUnits").checked
@@ -2459,6 +2610,72 @@ const char index_html[] PROGMEM = R"rawliteral(
           headers: { "Content-Type": "application/x-www-form-urlencoded" },
           body: "value=" + (val ? 1 : 0),
         });
+      }
+
+      // --- Buzzer ---
+      function setBuzzerEnabled(val) {
+        fetch("/set_buzzer", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "value=" + (val ? 1 : 0),
+        });
+      }
+
+      function saveBuzzerPin() {
+        const pin = document.getElementById("buzzerPin").value;
+        fetch("/save_pins", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "buzzer=" + encodeURIComponent(pin),
+        })
+          .then((r) => r.json())
+          .then(() => {
+            alert("Buzzer pin saved. Device will reboot...");
+          })
+          .catch((e) => console.error("save_pins failed:", e));
+      }
+
+      function testBuzzer() {
+        fetch("/action", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "buzzer_test=1",
+        });
+      }
+
+      // --- Physical Button ---
+      function setButtonEnabled(val) {
+        fetch("/set_button", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "value=" + (val ? 1 : 0),
+        });
+      }
+
+      function saveButtonPin() {
+        const pin = document.getElementById("buttonPin").value;
+        fetch("/save_pins", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "button=" + encodeURIComponent(pin),
+        })
+          .then((r) => r.json())
+          .then(() => {
+            alert("Button pin saved. Device will reboot...");
+          })
+          .catch((e) => console.error("save_pins failed:", e));
+      }
+
+      function saveButtonActions() {
+        fetch("/save_button_actions", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: "shortPress=" + encodeURIComponent(document.getElementById("buttonShortPress").value)
+              + "&longPress=" + encodeURIComponent(document.getElementById("buttonLongPress").value),
+        })
+          .then((r) => r.json())
+          .then(() => { alert("Button actions saved."); })
+          .catch((e) => console.error("save_button_actions failed:", e));
       }
 
       // --- Clock-only-during-dimming setter (no reboot) ---

--- a/README.md
+++ b/README.md
@@ -514,6 +514,25 @@ POST http://<device_ip>/action
 | `timer_resume` / `timer_start` | -- | Resume paused timer |
 | `timer_restart` | -- | Restart timer from original duration |
 
+#### 🔔 Buzzer
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `buzzer_beep` | -- | Trigger a single beep. Requires buzzer to be enabled and GPIO configured. |
+| `freq` | `1`–`20000` | Tone frequency in Hz. Default: `2000`. Must be sent alongside `buzzer_beep`. |
+| `durationMs` | `1`–`60000` | Beep duration in milliseconds. Default: `150`. Must be sent alongside `buzzer_beep`. |
+| `buzzer_stop` | -- | Immediately silence the buzzer and set `buzzerEnabled = false`. |
+
+> `freq` and `durationMs` are optional — omit either to use its default value.
+
+```bash
+# Default beep (2000 Hz, 150 ms)
+curl "http://<device_ip>/action?buzzer_beep=1"
+
+# Custom frequency and duration
+curl -X POST -d "buzzer_beep=1&freq=1000&durationMs=500" "http://<device_ip>/action"
+```
+
 #### ⚙️ System
 
 | Parameter | Value | Description |
@@ -521,6 +540,41 @@ POST http://<device_ip>/action
 | `clear_message` | -— | Clear current message, restore persistent UI message |
 | `save` | —- | Persist current settings to flash |
 | `restart` | -— | Reboot the device |
+
+&nbsp;
+### 📌 `/get_pins` Endpoint
+
+Returns the current GPIO pin assignments as JSON. Useful for reading back the active configuration without opening the Web UI.
+
+#### 🔗 Endpoint
+```
+GET http://<device_ip>/get_pins
+```
+
+#### 📤 Response
+
+```json
+{
+  "clk": 18,
+  "cs": 23,
+  "data": 5,
+  "buzzer": 4,
+  "button": 8
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `clk` | CLK / SCK pin connected to MAX7219 |
+| `cs` | CS / SS pin connected to MAX7219 |
+| `data` | DIN / MOSI pin connected to MAX7219 |
+| `buzzer` | GPIO pin for the buzzer (KY-006). `-1` = not configured |
+| `button` | GPIO pin for the physical button. `-1` = not configured |
+
+#### curl Example
+```bash
+curl http://<device_ip>/get_pins
+```
 
 > **Toggle behavior:** Sending a parameter without a value toggles it and jumps to the relevant display mode. 
 &nbsp;
@@ -674,7 +728,7 @@ curl "http://<device_ip>/action?display_off"
 
 ESPTimeCast supports an optional physical button that can be wired directly to your ESP board for hands-free control — no app or network required.
 
-The button template is included in the firmware but **disabled by default**. To enable it, simply uncomment the relevant lines and choose your GPIO pin.
+The button is **fully configurable from the Web UI** — no firmware changes or recompilation needed.
 
 ### Wiring
 
@@ -685,43 +739,43 @@ ESP GPIO pin  ──────────────  Button  ────�
 
 ### Setup
 
-In the firmware, find the **PHYSICAL BUTTON TEMPLATE** section and:
+1. Open the Web UI and go to **Hardware / Accessories → Physical Button**
+2. Select the **GPIO pin** connected to your button and click **Save Pin & Reboot**
+3. After reboot, toggle **Enable Button** to activate it
+4. Use the **Short Press Action** and **Long Press Action** dropdowns to configure what each press does, then click **Save Actions**
 
-1. Uncomment `#define BUTTON_PIN 4` and change `4` to your GPIO pin
-2. Uncomment the `handleButton()` function
-3. Uncomment the `pinMode` line in `setup()`
-4. Uncomment the `handleButton()` call in `loop()`
+No code editing required.
 
 ### Default Behavior
 
 | Press | Default Action | 
 |-------|----------------|
-| **Short press** | Advance to next display mode |
+| **Short press** | Next display mode |
 | **Long press** (800ms+) | Toggle display on/off |
 
-### Customization
+### Configurable Actions
 
-Both actions can be replaced with any `/action` parameter. Some examples:
-```cpp
-// Short press examples:
-executeAction("prev_mode", "");         // Go to previous mode
-executeAction("brightness_up", "");     // Increase brightness
-executeAction("enable_rotation", "");   // Toggle rotation freeze
-executeAction("go_to_mode", "clock");   // Jump to clock
+Both presses are independently configurable from the Web UI. Available options:
 
-// Long press examples:
-executeAction("restart", "");           // Reboot device
-executeAction("brightness_down", "");   // Decrease brightness
-executeAction("go_to_mode", "clock");   // Jump to clock
-executeAction("enable_rotation", "");   // Toggle rotation freeze
-```
+| Action | Description |
+|--------|-------------|
+| `next_mode` | Advance to next display mode *(short press default)* |
+| `prev_mode` | Go to previous display mode |
+| `display_off` | Toggle display on/off *(long press default)* |
+| `brightness_up` | Increase brightness by 1 |
+| `brightness_down` | Decrease brightness by 1 |
+| `enable_rotation` | Toggle automatic display rotation |
+| `buzzer_beep` | Play a confirmation beep (requires buzzer configured) |
+| `buzzer_stop` | Immediately silence and disable the buzzer |
+| `restart` | Reboot the device |
 
-> See the full list of available actions in the API & Home Assistant Integration section.
+Actions take effect immediately — no reboot needed. The selected actions are saved across reboots.
 
 ### Notes
-- The long press threshold defaults to **800ms** — change `BUTTON_LONG_PRESS_MS` to adjust
+- The long press threshold defaults to **800ms** — change `BUTTON_LONG_PRESS_MS` in the firmware to adjust
 - Short press fires on **button release** to avoid conflict with long press
-- Any GPIO pin can be used — check your board's pinout for available pins
+- The GPIO pin and enabled state are saved across reboots
+- ESP8266: all settings stored in `config.json`. ESP32: pin stored in NVS, actions in `config.json`
 - ESP8266 D-pin labels map to GPIO numbers (e.g. D2 = GPIO4)
   
 &nbsp;


### PR DESCRIPTION
@mfactory-osaka I have finally added some of the features that I was looking for as an alarm clock. For the time being the triggering and scheduling is handled by Home Assistant until #107 gets implemented
 
# Features

- Support Passive Buzzer and UI configuration (Example: [Passive Buzzer](https://arduinomodules.info/ky-006-passive-buzzer-module/)) #117

-  Buzzer API parameters: `/buzzer_beep=1&freq=1000&durationMs=500`

- Configure Button and (Short and Long) actions from the UI

- Add API endpoint `/get_pins` to display the currently configured GPIO PIN's
`{"clk":10,"cs":11,"data":12,"buzzer":6,"button":5}`


# UI

<img width="535" height="868" alt="CleanShot 2026-04-06 at 9  25 47" src="https://github.com/user-attachments/assets/f59e610c-f93e-493e-9db4-7ad8c2b8e20e" />



